### PR TITLE
Cifar params on cpu

### DIFF
--- a/tools/tensorflow/cnn/resnet/resnet_cifar10_multi_gpu.py
+++ b/tools/tensorflow/cnn/resnet/resnet_cifar10_multi_gpu.py
@@ -92,11 +92,20 @@ def train():
         #optimizer = tf.train.GradientDescentOptimizer(lr)
         optimizer = tf.train.MomentumOptimizer(lr, 0.9)
 
+        def assign_to_device(device, ps_device="/cpu:0"):
+            def _assign(op):
+                node_def = op if isinstance(op, tf.NodeDef) else op.node_def
+                if node_def.op == "Variable":
+                    return ps_device
+                else:
+                    return device
+            return _assign
+
         tower_grads = []
         average_loss_tensor = []
         for i in six.moves.range(FLAGS.num_gpus):
             print('what is i: ', i)
-            with tf.device('/gpu:%s'%device_ids[i]):
+            with tf.device(assign_to_device('/gpu:%s'%device_ids[i])):
                 with tf.name_scope('%s_%s' % ('TOWER', device_ids[i])) as n_scope:
                     images, labels = cifar10_input.inputs(False, FLAGS.data_dir, FLAGS.batch_size)
                     #logits = inference(images, is_training=True)


### PR DESCRIPTION
This change modifies CIFAR script to keep variables on CPU. This is what CNTK does and this seems to make a more direct comparison. Also, this makes results generalize to more machines, since differences in GPU p2p configuration will variability for GPU-hosted variables but not for CPU-hosted variables

Tested on 4x Pascal TitanX machine with 4-way p2p, and I'm seeing increase in rate (CUDA 7.5, TF 0.11). Effect should be greater on dual K80 setup. 

Before change:
```
2017-01-30 14:06:55.596072: step 100, loss = 2.40 (501.6 examples/sec; 0.255 sec
2017-01-30 14:07:20.038155: step 200, loss = 2.19 (536.3 examples/sec; 0.239 sec/batch)                                                                         2017-01-30 14:07:44.683135: step 300, loss = 2.11 (514.2 examples/sec; 0.249 sec
2017-01-30 14:08:09.284172: step 400, loss = 1.70 (513.4 examples/sec; 0.249 sec/batch)
2017-01-30 14:08:33.849163: step 500, loss = 1.60 (521.7 examples/sec; 0.245 sec/batch)

```

After change
```
2017-01-30 14:11:26.189051: step 200, loss = 2.50 (570.9 examples/sec; 0.224 sec/batch)
2017-01-30 14:11:48.245017: step 300, loss = 2.19 (580.8 examples/sec; 0.220 sec/batch)
= 2.04 (581.6 examples/sec; 0.220 sec/batch)
2017-01-30 14:12:32.208097: step 500, loss = 2.00 (583.2 examples/sec; 0.219 sec/batch)

```