### PR TITLE
Minor performance tweaks to match the guide.

### DIFF
--- a/tools/tensorflow/cnn/alexnet/alexnet_cifar10_multi_gpu.py
+++ b/tools/tensorflow/cnn/alexnet/alexnet_cifar10_multi_gpu.py
@@ -36,6 +36,8 @@ tf.app.flags.DEFINE_boolean('use_fp16', False,
 tf.app.flags.DEFINE_boolean('log_device_placement', True,
                             """Whether to log device placement.""")
 tf.app.flags.DEFINE_integer('num_gpus', 2, """How many GPUs to use.""")
+tf.app.flags.DEFINE_string('local_ps_device', 'GPU:0', """Local parameter server GPU:0 if gpus are peered or CPU:0 otherwise try both.""")
+
 
 EPOCH_SIZE = 50000
 TEST_SIZE = 10000
@@ -213,7 +215,7 @@ def average_gradients(tower_grads):
 def train():
     global parameters
     config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=FLAGS.log_device_placement)
-    with tf.Graph().as_default(), tf.device("/cpu:0"):
+    with tf.Graph().as_default(), tf.device("/" + FLAGS.local_ps_device):
         global_step = tf.get_variable('global_step', [], initializer=tf.constant_initializer(0), trainable=False)
 
         device_ids = FLAGS.device_ids
@@ -231,7 +233,7 @@ def train():
         #optimizer = tf.train.GradientDescentOptimizer(lr)
         optimizer = tf.train.MomentumOptimizer(lr, 0.9)
 
-        def assign_to_device(device, ps_device="/cpu:0"):
+        def assign_to_device(device, ps_device="/" + FLAGS.local_ps_device):
             def _assign(op):
                 node_def = op if isinstance(op, tf.NodeDef) else op.node_def
                 if node_def.op == "Variable":

--- a/tools/tensorflow/cnn/alexnet/alexnet_cifar10_multi_gpu.py
+++ b/tools/tensorflow/cnn/alexnet/alexnet_cifar10_multi_gpu.py
@@ -315,6 +315,7 @@ def train():
 
 
 def main(_):
+    os.environ['TF_ENABLE_WINOGRAD_NONFUSED'] = '1'
     train()
 
 

--- a/tools/tensorflow/cnn/alexnet/alexnet_cifar10_multi_gpu.py
+++ b/tools/tensorflow/cnn/alexnet/alexnet_cifar10_multi_gpu.py
@@ -25,7 +25,7 @@ tf.app.flags.DEFINE_integer('batch_size', 1024, """Number of images to process i
 tf.app.flags.DEFINE_integer('epochs', 40, """Max epochs for training.""")
 tf.app.flags.DEFINE_integer('log_step', 100, """Log step""")
 tf.app.flags.DEFINE_integer('eval_step', 1, """Evaluate step of epoch""")
-tf.app.flags.DEFINE_string('device_ids', '0,1', """Device ids. split by comma, e.g. 0,1""")
+tf.app.flags.DEFINE_string('device_ids', '', """Device ids. split by comma, e.g. 0,1""")
 #tf.app.flags.DEFINE_string('data_dir', '/home/comp/csshshi/data/tensorflow/cifar10/cifar-10-batches-bin', """Data directory""")
 tf.app.flags.DEFINE_string('data_dir', os.environ['HOME']+'/data/tensorflow/cifar10/cifar-10-batches-bin', """Data directory""")
 #tf.app.flags.DEFINE_string('data_dir', '/home/comp/pengfeixu/Data/tensorflow/cifar10/cifar-10-batches-bin', """Data directory""")
@@ -216,7 +216,12 @@ def train():
     with tf.Graph().as_default(), tf.device("/cpu:0"):
         global_step = tf.get_variable('global_step', [], initializer=tf.constant_initializer(0), trainable=False)
 
-        device_ids = FLAGS.device_ids.split(',')
+        device_ids = FLAGS.device_ids
+        if not device_ids:
+            device_ids = [str(i) for i in range(FLAGS.num_gpus)]
+        else:
+            device_ids = device_ids.split(',')
+
         print('device_ids: ', device_ids)
         if len(device_ids) > FLAGS.num_gpus:
             print('The device_ids should have the same number of GPUs with num_gpus')

--- a/tools/tensorflow/cnn/resnet/cifar10_eval.py
+++ b/tools/tensorflow/cnn/resnet/cifar10_eval.py
@@ -132,7 +132,7 @@ def evaluate():
     # Build a Graph that computes the logits predictions from the
     # inference model.
     #logits = inference(images, is_training=False)
-    logits = inference_small(images, is_training=True, num_blocks=9)
+    logits = inference_small(images, is_training=False, num_blocks=9)
 
     # Calculate predictions.
     top_k_op = tf.nn.in_top_k(logits, labels, 1)
@@ -145,9 +145,9 @@ def evaluate():
     saver = tf.train.Saver()
 
     # Build the summary operation based on the TF collection of Summaries.
-    summary_op = tf.merge_all_summaries()
+    summary_op = tf.summary.merge_all()
 
-    summary_writer = tf.train.SummaryWriter(FLAGS.eval_dir, g)
+    summary_writer = tf.summary.FileWriter(FLAGS.eval_dir, g)
 
     while True:
       eval_once(saver, summary_writer, top_k_op, summary_op)

--- a/tools/tensorflow/cnn/resnet/resnet.py
+++ b/tools/tensorflow/cnn/resnet/resnet.py
@@ -87,11 +87,9 @@ def loss(logits, labels):
     cross_entropy_mean = tf.reduce_mean(cross_entropy)
  
     regularization_losses = tf.get_collection(tf.GraphKeys.REGULARIZATION_LOSSES)
-
-    loss_ = tf.add_n([cross_entropy_mean] + regularization_losses)
-    tf.summary.scalar('loss', loss_)
-
-    return loss_
+    total_loss = tf.add_n([cross_entropy_mean] + regularization_losses, name='total_loss')
+    
+    return total_loss
 
 
 def stack(x, c):

--- a/tools/tensorflow/cnn/resnet/resnet.py
+++ b/tools/tensorflow/cnn/resnet/resnet.py
@@ -40,9 +40,7 @@ def inference_small(x,
                     use_bias=False, # defaults to using batch norm
                     num_classes=10):
     c = Config()
-    c['is_training'] = tf.convert_to_tensor(is_training,
-                                            dtype='bool',
-                                            name='is_training')
+    c['is_training'] = is_training
     c['use_bias'] = use_bias
     c['fc_units_out'] = num_classes
     c['num_blocks'] = num_blocks
@@ -173,38 +171,9 @@ def bn(x, c):
                              initializer=tf.zeros_initializer())
         return x + bias
 
-
-    axis = list(range(len(x_shape) - 1))
-
-    beta = _get_variable('beta',
-                         params_shape,
-                         initializer=tf.zeros_initializer())
-    gamma = _get_variable('gamma',
-                          params_shape,
-                          initializer=tf.ones_initializer())
-
-    moving_mean = _get_variable('moving_mean',
-                                params_shape,
-                                initializer=tf.zeros_initializer(),
-                                trainable=False)
-    moving_variance = _get_variable('moving_variance',
-                                    params_shape,
-                                    initializer=tf.ones_initializer(),
-                                    trainable=False)
-
-    # These ops will only be preformed when training.
-    mean, variance = tf.nn.moments(x, axis)
-    update_moving_mean = moving_averages.assign_moving_average(moving_mean,mean, BN_DECAY)
-    update_moving_variance = moving_averages.assign_moving_average(moving_variance, variance, BN_DECAY)
-    tf.add_to_collection(UPDATE_OPS_COLLECTION, update_moving_mean)
-    tf.add_to_collection(UPDATE_OPS_COLLECTION, update_moving_variance)
-
-    mean, variance = control_flow_ops.cond(
-        c['is_training'], lambda: (mean, variance),
-        lambda: (moving_mean, moving_variance))
-
-    x = tf.nn.batch_normalization(x, mean, variance, beta, gamma, BN_EPSILON)
-    #x.set_shape(inputs.get_shape()) ??
+    batch_norm_config = {'decay': 0.999, 'epsilon': 1e-5, 'scale': True, 'center': True}
+    x = tf.contrib.layers.batch_norm(x, is_training=c['is_training'], fused=True,
+                                     data_format='NHWC', **batch_norm_config)
 
     return x
 

--- a/tools/tensorflow/cnn/resnet/resnet_cifar10_multi_gpu.py
+++ b/tools/tensorflow/cnn/resnet/resnet_cifar10_multi_gpu.py
@@ -93,16 +93,17 @@ def train():
         optimizer = tf.train.MomentumOptimizer(lr, 0.9)
 
         def assign_to_device(device, ps_device="/cpu:0"):
+            #if FLAGS.num_gpus == 1:
+            #    ps_device="/gpu:0"
             def _assign(op):
                 node_def = op if isinstance(op, tf.NodeDef) else op.node_def
-                if node_def.op == "Variable":
+                if node_def.op in ["Variable","VariableV2"]:
                     return ps_device
                 else:
                     return device
             return _assign
 
         tower_grads = []
-        average_loss_tensor = []
         reuse_variables = None
         losses = []
         for i in six.moves.range(FLAGS.num_gpus):
@@ -115,36 +116,20 @@ def train():
                     #logits = inference(images, is_training=True)
                     with tf.variable_scope(tf.get_variable_scope(), reuse=reuse_variables):
                         logits = inference_small(images, is_training=True, num_blocks=9)
-                        loss_tensor = loss(logits, labels)
-                        losses.append(loss_tensor)
-                    #tf.add_to_collection('losses', loss_tensor)
-                    #tf.add_n(tf.get_collection('losses'), name='total_loss')
-
-                    #losses = tf.get_collection('losses', n_scope)
-                    #total_loss = tf.add_n(losses, name='total_loss')
-                    # average_loss_tensor.append(loss_tensor)
-                    
-                    #update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-                    #with tf.control_dependencies(update_ops):
-                    grads = optimizer.compute_gradients(loss_tensor)
+                    tower_loss = loss(logits, labels)
+                    losses.append(tower_loss)
+                    grads = optimizer.compute_gradients(tower_loss)
                     tower_grads.append(grads)
                     reuse_variables = True
         
-        total_loss = tf.add_n(losses, name='total_loss')
-        update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS, 'TOWER_0')
         
+        update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS, 'TOWER_0')
         with tf.control_dependencies(update_ops):
+            # Average losses accross towers (GPUs)
+            total_loss = tf.reduce_mean(losses, 0)
             grads = average_gradients(tower_grads)
             apply_gradient_op = optimizer.apply_gradients(grads, global_step=global_step)
         train_op = apply_gradient_op
-
-        #update_ops.append(apply_gradient_op)
-
-        #update_op = tf.group(*update_ops)
-        #train_op = control_flow_ops.with_dependencies([update_op], total_loss,
-        #                                              name='train_op')
-
-        # average_op = tf.reduce_mean(average_loss_tensor, 0)
 
         # Create a saver.
         saver = tf.train.Saver(tf.global_variables())

--- a/tools/tensorflow/cnn/resnet/resnet_cifar10_multi_gpu.py
+++ b/tools/tensorflow/cnn/resnet/resnet_cifar10_multi_gpu.py
@@ -28,7 +28,9 @@ tf.app.flags.DEFINE_boolean('use_fp16', False,
 tf.app.flags.DEFINE_boolean('log_device_placement', False,
                             """Whether to log device placement.""")
 tf.app.flags.DEFINE_integer('num_gpus', 2, """How many GPUs to use.""")
-tf.app.flags.DEFINE_string('local_ps_device', 'GPU:0', """Local parameter server GPU:0 if gpus are peered or CPU:0 otherwise try both.""")
+# CPU:0 is best for ResNet regardless of peering.  I do not know about CIFAR on P100 but even 
+# on the P100 via the DGX-1 CPU is the better choice.  
+tf.app.flags.DEFINE_string('local_ps_device', 'CPU:0', """Local parameter server GPU:0 if gpus are peered or CPU:0 otherwise try both.""")
 
 EPOCH_SIZE = 50000
 TEST_SIZE = 10000


### PR DESCRIPTION
I believe these are still NHWC which I did not want to mess with.  I fixed the following:
- Input pipeline on CPU
- batch_norm fused
- for AlexNet I moved the local_ps_device to GPU which is the better option if the GPUs are peered and about equal to CPU:0 otherwise.  No fancy NCCL which does not seem to work well on K80s and no non-NCCL replicated variables which would likely speed this up as well. 
- I added a flag to both for local_ps_device and set it to the default that I expect works the best on K80s and likely P100s as well.  
- I fixed the eval to set is_training = False.  Does not matter for perf testing but that is how it is supposed to be.
- ResNet also converges to a slightly better loss now due to a change in the learning rate.  It could be better but I was not interested in adding a learning rate decay right now.  
- AlexNet converges to the same level as before but I think a little faster but that might be luck.
- I noticed your K80 is clocked at ~500Mhz.  The normal is ~845Mhz that seemed weird but I assume consistent.  
- I also did some general cleanup where the losses were added to a collection and then taken out and then added to nothing and then I am not sure what it was but it was not needed.  
Finally, off the top of my head the numbers I see:
- AlexNet 4 GPUs  ~70ms on AWS with 4 K80s using the CPU as the PS_server this is ~100ms
- ResNet 4 GPUs ~140ms on AWS and Google Cloud
- Both are I think 50% or more savings in time or 2x speedup or whatever.

Some people think that the batch_norm is not doing beta and gamma.  Check the code it is built into the function you should do not control how it is initialized.

Finally, the changes I made are not esoteric.  I just added the basic that I would suggest for anyone else.  I might change it over to NCHW but this seemed good enough for now.  I think we are about to push a "crazy" alexnet in our benchmark that uses some fun staging ops but I did not want to mess up your scripts.  
