### PR TITLE
Alexnet NCHW, split variables across GPUs and DataSet support

### DIFF
--- a/tools/tensorflow/cnn/alexnet/alexnet_cifar10.py
+++ b/tools/tensorflow/cnn/alexnet/alexnet_cifar10.py
@@ -35,6 +35,9 @@ tf.app.flags.DEFINE_boolean('use_fp16', False,
 tf.app.flags.DEFINE_boolean('log_device_placement', False,
                             """Whether to log device placement.""")
 
+data_format = 'NCHW'
+data_format_c = 'channels_first'
+
 EPOCH_SIZE = 50000
 TEST_SIZE = 10000
 
@@ -52,20 +55,37 @@ def _conv(inpOp, nIn, nOut, kH, kW, dH, dW, padType):
     global parameters
     name = 'conv' + str(conv_counter)
     conv_counter += 1
-    with tf.name_scope(name) as scope:
-        kernel = tf.Variable(tf.truncated_normal([kH, kW, nIn, nOut],
-                                                 dtype=tf.float32,
-                                                 stddev=1e-2), name='weights')
+    print('conv_name:{}'.format(name))
+    with tf.variable_scope(name):
+        #kernel = tf.Variable(tf.truncated_normal([kH, kW, nIn, nOut],
+                                                # dtype=tf.float32,
+                                                # stddev=1e-2), name='weights')
         #kernel = tf.Variable(tf.random_normal([kH, kW, nIn, nOut],
         #                                         dtype=tf.float32,
         #                                         stddev=1e-2), name='weights')
-        strides = [1, dH, dW, 1]
-        conv = tf.nn.conv2d(inpOp, kernel, strides, padding=padType)
-        biases = tf.Variable(tf.constant(0.0, shape=[nOut], dtype=tf.float32),
-                             trainable=True, name='biases')
-        bias = tf.reshape(tf.nn.bias_add(conv, biases),
+        #strides = [1, 1, dH, dW]
+        #conv = tf.nn.conv2d(inpOp, kernel, strides, padding=padType, data_format=data_format)
+
+        kernel_initializer = tf.truncated_normal_initializer(stddev=1e-2)
+        conv = tf.layers.conv2d(inpOp,
+                        nOut, 
+                        [kH, kW],
+                        strides=[dH, dW],
+                        padding=padType,
+                        data_format=data_format_c,
+                        kernel_initializer=kernel_initializer,
+                        use_bias=False)
+
+        print('conv before biases:',conv)
+
+        #biases = tf.Variable(tf.constant(0.0, shape=[nOut], dtype=tf.float32),
+                             #trainable=True, name='biases')
+        biases = tf.get_variable(
+                        'biases', [nOut], tf.float32,
+                        tf.constant_initializer(0.0))
+        bias = tf.reshape(tf.nn.bias_add(conv, biases, data_format=data_format),
                           conv.get_shape())
-        parameters += [kernel, biases]
+        #parameters += [kernel, biases]
         return bias
 
 
@@ -74,7 +94,8 @@ def _relu(inpOp):
 
 
 def _padding(inpOp, pad):
-    padded_input = tf.pad(inpOp, [[0, 0], [pad, pad], [pad, pad], [0, 0]], "CONSTANT")
+    padded_input = tf.pad(inpOp, [[0, 0], [0, 0], [pad, pad], [pad, pad]], "CONSTANT")
+    #padded_input = tf.pad(inpOp, [[0, 0], [pad, pad], [pad, pad], [0, 0]], "CONSTANT")
     print('padded_input: ', padded_input)
     return padded_input
     #return inpOp
@@ -93,50 +114,76 @@ def _affine(inpOp, nIn, nOut):
     name = 'affine' + str(affine_counter)
     affine_counter += 1
     with tf.name_scope(name) as scope:
-        kernel = tf.Variable(tf.truncated_normal([nIn, nOut],
-                                                 dtype=tf.float32,
-                                                 stddev=1e-2), name='weights')
+        #kernel = tf.Variable(tf.truncated_normal([nIn, nOut],
+        #                                         dtype=tf.float32,
+        #                                         stddev=1e-2), name='weights')
+        
         #kernel = tf.Variable(tf.random_normal([nIn, nOut],
         #                                         dtype=tf.float32,
         #                                         stddev=1e-2), name='weights')
-        biases = tf.Variable(tf.constant(0.0, shape=[nOut], dtype=tf.float32),
-                             trainable=True, name='biases')
-        affine1 = tf.nn.relu_layer(inpOp, kernel, biases, name=name)
-        parameters += [kernel, biases]
-        return affine1
+        
+        #biases = tf.Variable(tf.constant(0.0, shape=[nOut], dtype=tf.float32),
+        #                     trainable=True, name='biases')
+        #affine1 = tf.nn.relu_layer(inpOp, kernel, biases, name=name)
+        #parameters += [kernel, biases]
+        #return affine1
+        kernel = tf.get_variable(
+            'weights', [nIn, nOut],
+            tf.float32,
+            tf.truncated_normal_initializer(stddev=1e-2))
+        biases = tf.get_variable('biases', [nOut],
+                                 tf.float32,
+                                 tf.constant_initializer(0.1))
+        logits = tf.matmul(inpOp, kernel) + biases
+        return tf.nn.relu(logits, name=name)
 
 def _mpool(inpOp, kH, kW, dH, dW):
     global pool_counter
     global parameters
     name = 'pool' + str(pool_counter)
     pool_counter += 1
-    ksize = [1, kH, kW, 1]
-    strides = [1, dH, dW, 1]
-    return tf.nn.max_pool(inpOp,
-                          ksize=ksize,
-                          strides=strides,
-                          padding='VALID',
-                          name=name)
+    #ksize = [1, kH, kW, 1]
+    #strides = [1, 1, dH, dW ]
+    return tf.layers.max_pooling2d(
+        inpOp, [kH, kW], [dH, dW],
+        padding='VALID',
+        data_format=data_format_c,
+        name=name)    
+    #return tf.nn.max_pool(inpOp,
+    #                      ksize=ksize,
+    #                      strides=strides,
+    #                      padding='VALID',
+    #                      name=name,
+    #                      data_format=data_format)
 
 def _avgpool(inpOp, kH, kW, dH, dW):
     global pool_counter
     name = 'pool' + str(pool_counter)
     pool_counter += 1
-    ksize = [1, kH, kW, 1]
-    strides = [1, dH, dW, 1]
-    return tf.nn.avg_pool(inpOp,
-                          ksize=ksize,
-                          strides=strides,
-                          padding='VALID',
-                          name=name)
+    #ksize = [1, kH, kW, 1]
+    #strides = [1, 1, dH, dW]
+    return tf.layers.average_pooling2d(
+        inpOp, [kH, kW], [dH, dW],
+        padding='VALID',
+        data_format=data_format_c,
+        name=name)
+    #return tf.nn.avg_pool(inpOp,
+    #                      ksize=ksize,
+    #                      strides=strides,
+    #                      padding='VALID',
+    #                      name=name,
+    #                      data_format=data_format)
 
 def loss(logits, labels):
+    print(labels)
     batch_size = tf.size(labels)
     labels = tf.expand_dims(labels, 1)
     indices = tf.expand_dims(tf.range(0, batch_size, 1), 1)
     concated = tf.concat(axis=1, values=[indices, labels])
     onehot_labels = tf.sparse_to_dense(
         concated, tf.stack([batch_size, 10]), 1.0, 0.0)
+    print(logits)
+    print(onehot_labels)
     cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=logits,
                                                             labels=onehot_labels,
                                                             name='xentropy')
@@ -144,15 +191,20 @@ def loss(logits, labels):
     return loss
 
 def inference(images):
+    print('images Interence########{}'.format(images))
+    images = tf.transpose(images, [0, 3, 1, 2])
     pad1 = _padding(images, 2) 
     conv1 = _conv (pad1, 3, 32, 5, 5, 1, 1, 'VALID')
+    print('conv1:{}'.format(conv1))
     pool1 = _mpool(conv1,  3, 3, 2, 2)
+    print('pool1:{}'.format(conv1))
     relu1 = _relu(pool1)
+    print('REUL:{}'.format(relu1))
     #norm1 = _norm(relu1, 3, 5e-05, 0.75)
 
     pad2 = _padding(relu1, 2)
-    conv2 = _conv (pad2,  32, 32, 5, 5, 1, 1, 'VALID')
-    pool2 = _mpool(conv2,  3, 3, 2, 2)
+    conv2 = _conv (pad2, 32, 32, 5, 5, 1, 1, 'VALID')
+    pool2 = _mpool(conv2, 3, 3, 2, 2)
     relu2 = _relu(pool2)
     #norm2 = _norm(relu2, 3, 5e-05, 0.75)
 
@@ -160,14 +212,23 @@ def inference(images):
     conv3 = _conv (pad3,  32, 64, 5, 5, 1, 1, 'VALID')
     relu3 = _relu(conv3)
     pool3 = _avgpool(relu3, 3, 3, 2, 2) 
-    print('pool3: ', pool3)
+
+    #resh1 = tf.reshape(pool3, [-1, 64 * 3 * 3])
+    print('pool3: {}'.format(pool3))
 
     resh1 = tf.reshape(pool3, [-1, 64 * 3 * 3])
+    print('post reshape:{} '.format(resh1))
+
     affn1 = _affine(resh1, 64*3*3, 10)
+
+    shape = affn1.get_shape().as_list()
+    flat_dim = shape[1]
+    #resh1 = tf.reshape(pool3, [-1,flat_dim])
 
     return affn1
 
 def inference2(images):
+    images = tf.transpose(images, [0, 3, 1, 2])
     #pad1 = _padding(images, 2) 
     conv1 = _conv (images, 3, 32, 5, 5, 1, 1, 'SAME')
     pool1 = _mpool(conv1,  3, 3, 2, 2)
@@ -184,9 +245,11 @@ def inference2(images):
     conv3 = _conv (relu2,  32, 64, 5, 5, 1, 1, 'SAME')
     relu3 = _relu(conv3)
     pool3 = _avgpool(relu3, 3, 3, 2, 2) 
-    print('pool3: ', pool3)
+    print('pool3: {}'.format(pool3))
 
     resh1 = tf.reshape(pool3, [-1, 64 * 3 * 3])
+    print('post reshape:{} '.format(resh1))
+
     affn1 = _affine(resh1, 64*3*3, 10)
 
     return affn1
@@ -195,6 +258,7 @@ def inference2(images):
 def train():
   global parameters
   config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=FLAGS.log_device_placement)
+  #config.graph_options.optimizer_options.global_jit_level = tf.OptimizerOptions.ON_1
   device_str = get_device_str(FLAGS.device_id)
   if device_str.find('cpu') >= 0: # cpu version
       num_threads = os.getenv('OMP_NUM_THREADS', 1)
@@ -203,9 +267,10 @@ def train():
   with tf.Graph().as_default(), tf.device(device_str), tf.Session(config=config) as sess:
       #image_size = 32 
       #images, labels = cifar10_input.distorted_inputs(FLAGS.data_dir, FLAGS.batch_size)
-      images, labels = cifar10_input.inputs(False, FLAGS.data_dir, FLAGS.batch_size)
+      #images, labels = cifar10_input.inputs(False, FLAGS.data_dir, FLAGS.batch_size)
       with tf.device('/cpu:0'):
         images, labels = cifar10_input.inputs(False, FLAGS.data_dir, FLAGS.batch_size)
+        print(images)
       print('Images: ', images)
 
       logits = inference(images)
@@ -227,7 +292,6 @@ def train():
       coord = tf.train.Coordinator()
       threads = tf.train.start_queue_runners(sess=sess, coord=coord)
 
-
       real_batch_size = FLAGS.batch_size
       num_batches_per_epoch = int((EPOCH_SIZE + real_batch_size - 1)/ real_batch_size)
       iterations = FLAGS.epochs * num_batches_per_epoch 
@@ -238,8 +302,8 @@ def train():
       for step in xrange(iterations):
           start_time = time.time()
           _, loss_v = sess.run([grad, loss_value])
-          average_loss += loss_v
           duration = time.time() - start_time
+          average_loss += loss_v
           average_batch_time += float(duration)
           assert not np.isnan(loss_v), 'Model diverged with loss = NaN'
           if step % FLAGS.log_step == 0:
@@ -263,6 +327,8 @@ def train():
 
 
 def main(_):
+    os.environ['TF_SYNC_ON_FINISH'] = '0'
+    os.environ['TF_ENABLE_WINOGRAD_NONFUSED'] = '1'
     train()
 
 

--- a/tools/tensorflow/cnn/alexnet/alexnet_cifar10.py
+++ b/tools/tensorflow/cnn/alexnet/alexnet_cifar10.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import time
 import cifar10_input
-#import unpickle as cifar10_input
 
 import tensorflow as tf
 import numpy as np
@@ -34,6 +33,7 @@ tf.app.flags.DEFINE_boolean('use_fp16', False,
                             """Train the model using fp16.""")
 tf.app.flags.DEFINE_boolean('log_device_placement', False,
                             """Whether to log device placement.""")
+tf.app.flags.DEFINE_boolean('use_dataset', False, """True to use datasets""")
 
 data_format = 'NCHW'
 data_format_c = 'channels_first'
@@ -52,20 +52,9 @@ def get_device_str(device_id):
 
 def _conv(inpOp, nIn, nOut, kH, kW, dH, dW, padType):
     global conv_counter
-    global parameters
     name = 'conv' + str(conv_counter)
     conv_counter += 1
-    print('conv_name:{}'.format(name))
     with tf.variable_scope(name):
-        #kernel = tf.Variable(tf.truncated_normal([kH, kW, nIn, nOut],
-                                                # dtype=tf.float32,
-                                                # stddev=1e-2), name='weights')
-        #kernel = tf.Variable(tf.random_normal([kH, kW, nIn, nOut],
-        #                                         dtype=tf.float32,
-        #                                         stddev=1e-2), name='weights')
-        #strides = [1, 1, dH, dW]
-        #conv = tf.nn.conv2d(inpOp, kernel, strides, padding=padType, data_format=data_format)
-
         kernel_initializer = tf.truncated_normal_initializer(stddev=1e-2)
         conv = tf.layers.conv2d(inpOp,
                         nOut, 
@@ -75,17 +64,12 @@ def _conv(inpOp, nIn, nOut, kH, kW, dH, dW, padType):
                         data_format=data_format_c,
                         kernel_initializer=kernel_initializer,
                         use_bias=False)
-
-        print('conv before biases:',conv)
-
-        #biases = tf.Variable(tf.constant(0.0, shape=[nOut], dtype=tf.float32),
-                             #trainable=True, name='biases')
         biases = tf.get_variable(
                         'biases', [nOut], tf.float32,
                         tf.constant_initializer(0.0))
+
         bias = tf.reshape(tf.nn.bias_add(conv, biases, data_format=data_format),
                           conv.get_shape())
-        #parameters += [kernel, biases]
         return bias
 
 
@@ -95,10 +79,7 @@ def _relu(inpOp):
 
 def _padding(inpOp, pad):
     padded_input = tf.pad(inpOp, [[0, 0], [0, 0], [pad, pad], [pad, pad]], "CONSTANT")
-    #padded_input = tf.pad(inpOp, [[0, 0], [pad, pad], [pad, pad], [0, 0]], "CONSTANT")
-    print('padded_input: ', padded_input)
     return padded_input
-    #return inpOp
 
 
 def _norm(inpOp, local_size, alpha, beta):
@@ -114,19 +95,6 @@ def _affine(inpOp, nIn, nOut):
     name = 'affine' + str(affine_counter)
     affine_counter += 1
     with tf.name_scope(name) as scope:
-        #kernel = tf.Variable(tf.truncated_normal([nIn, nOut],
-        #                                         dtype=tf.float32,
-        #                                         stddev=1e-2), name='weights')
-        
-        #kernel = tf.Variable(tf.random_normal([nIn, nOut],
-        #                                         dtype=tf.float32,
-        #                                         stddev=1e-2), name='weights')
-        
-        #biases = tf.Variable(tf.constant(0.0, shape=[nOut], dtype=tf.float32),
-        #                     trainable=True, name='biases')
-        #affine1 = tf.nn.relu_layer(inpOp, kernel, biases, name=name)
-        #parameters += [kernel, biases]
-        #return affine1
         kernel = tf.get_variable(
             'weights', [nIn, nOut],
             tf.float32,
@@ -142,19 +110,11 @@ def _mpool(inpOp, kH, kW, dH, dW):
     global parameters
     name = 'pool' + str(pool_counter)
     pool_counter += 1
-    #ksize = [1, kH, kW, 1]
-    #strides = [1, 1, dH, dW ]
     return tf.layers.max_pooling2d(
         inpOp, [kH, kW], [dH, dW],
         padding='VALID',
         data_format=data_format_c,
         name=name)    
-    #return tf.nn.max_pool(inpOp,
-    #                      ksize=ksize,
-    #                      strides=strides,
-    #                      padding='VALID',
-    #                      name=name,
-    #                      data_format=data_format)
 
 def _avgpool(inpOp, kH, kW, dH, dW):
     global pool_counter
@@ -167,39 +127,19 @@ def _avgpool(inpOp, kH, kW, dH, dW):
         padding='VALID',
         data_format=data_format_c,
         name=name)
-    #return tf.nn.avg_pool(inpOp,
-    #                      ksize=ksize,
-    #                      strides=strides,
-    #                      padding='VALID',
-    #                      name=name,
-    #                      data_format=data_format)
 
 def loss(logits, labels):
-    print(labels)
-    batch_size = tf.size(labels)
-    labels = tf.expand_dims(labels, 1)
-    indices = tf.expand_dims(tf.range(0, batch_size, 1), 1)
-    concated = tf.concat(axis=1, values=[indices, labels])
-    onehot_labels = tf.sparse_to_dense(
-        concated, tf.stack([batch_size, 10]), 1.0, 0.0)
-    print(logits)
-    print(onehot_labels)
     cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=logits,
-                                                            labels=onehot_labels,
+                                                            labels=labels,
                                                             name='xentropy')
     loss = tf.reduce_mean(cross_entropy, name='xentropy_mean')
     return loss
 
 def inference(images):
-    print('images Interence########{}'.format(images))
-    images = tf.transpose(images, [0, 3, 1, 2])
     pad1 = _padding(images, 2) 
     conv1 = _conv (pad1, 3, 32, 5, 5, 1, 1, 'VALID')
-    print('conv1:{}'.format(conv1))
     pool1 = _mpool(conv1,  3, 3, 2, 2)
-    print('pool1:{}'.format(conv1))
     relu1 = _relu(pool1)
-    print('REUL:{}'.format(relu1))
     #norm1 = _norm(relu1, 3, 5e-05, 0.75)
 
     pad2 = _padding(relu1, 2)
@@ -213,43 +153,7 @@ def inference(images):
     relu3 = _relu(conv3)
     pool3 = _avgpool(relu3, 3, 3, 2, 2) 
 
-    #resh1 = tf.reshape(pool3, [-1, 64 * 3 * 3])
-    print('pool3: {}'.format(pool3))
-
     resh1 = tf.reshape(pool3, [-1, 64 * 3 * 3])
-    print('post reshape:{} '.format(resh1))
-
-    affn1 = _affine(resh1, 64*3*3, 10)
-
-    shape = affn1.get_shape().as_list()
-    flat_dim = shape[1]
-    #resh1 = tf.reshape(pool3, [-1,flat_dim])
-
-    return affn1
-
-def inference2(images):
-    images = tf.transpose(images, [0, 3, 1, 2])
-    #pad1 = _padding(images, 2) 
-    conv1 = _conv (images, 3, 32, 5, 5, 1, 1, 'SAME')
-    pool1 = _mpool(conv1,  3, 3, 2, 2)
-    relu1 = _relu(pool1)
-    #norm1 = _norm(relu1, 3, 5e-05, 0.75)
-
-    #pad2 = _padding(relu1, 2)
-    conv2 = _conv (relu1,  32, 32, 5, 5, 1, 1, 'SAME')
-    pool2 = _mpool(conv2,  3, 3, 2, 2)
-    relu2 = _relu(pool2)
-    #norm2 = _norm(relu2, 3, 5e-05, 0.75)
-
-    #pad3 = _padding(relu2, 2)
-    conv3 = _conv (relu2,  32, 64, 5, 5, 1, 1, 'SAME')
-    relu3 = _relu(conv3)
-    pool3 = _avgpool(relu3, 3, 3, 2, 2) 
-    print('pool3: {}'.format(pool3))
-
-    resh1 = tf.reshape(pool3, [-1, 64 * 3 * 3])
-    print('post reshape:{} '.format(resh1))
-
     affn1 = _affine(resh1, 64*3*3, 10)
 
     return affn1
@@ -258,28 +162,30 @@ def inference2(images):
 def train():
   global parameters
   config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=FLAGS.log_device_placement)
-  #config.graph_options.optimizer_options.global_jit_level = tf.OptimizerOptions.ON_1
+  config.intra_op_parallelism_threads = 1
+  config.inter_op_parallelism_threads = 0
   device_str = get_device_str(FLAGS.device_id)
   if device_str.find('cpu') >= 0: # cpu version
       num_threads = os.getenv('OMP_NUM_THREADS', 1)
       print 'num_threads: ', num_threads
       config = tf.ConfigProto(allow_soft_placement=True, intra_op_parallelism_threads=int(num_threads))
   with tf.Graph().as_default(), tf.device(device_str), tf.Session(config=config) as sess:
-      #image_size = 32 
-      #images, labels = cifar10_input.distorted_inputs(FLAGS.data_dir, FLAGS.batch_size)
-      #images, labels = cifar10_input.inputs(False, FLAGS.data_dir, FLAGS.batch_size)
+      initalizer = None
+      images = None
+      labels = None
       with tf.device('/cpu:0'):
-        images, labels = cifar10_input.inputs(False, FLAGS.data_dir, FLAGS.batch_size)
-        print(images)
-      print('Images: ', images)
+        if FLAGS.use_dataset:
+          iterator, initalizer =  cifar10_input.dataSet(FLAGS.data_dir, FLAGS.batch_size)
+          images, labels = iterator.get_next()
+        else:
+          images, labels = cifar10_input.inputs(False, FLAGS.data_dir, FLAGS.batch_size)
 
+      labels = tf.contrib.layers.one_hot_encoding(labels, 10)
       logits = inference(images)
-      #logits = inference2(images)
       # Add a simple objective so we can calculate the backward pass.
       loss_value = loss(logits, labels)
       # Compute the gradient with respect to all the parameters.
       lr = 0.001
-      #grad = tf.train.GradientDescentOptimizer(lr).minimize(loss_value)
       grad = tf.train.MomentumOptimizer(lr, 0.9).minimize(loss_value)
 
       # Create a saver.
@@ -289,9 +195,13 @@ def train():
       init = tf.global_variables_initializer()
       # Start running operations on the Graph.
       sess.run(init)
-      coord = tf.train.Coordinator()
-      threads = tf.train.start_queue_runners(sess=sess, coord=coord)
-
+      coord = None
+      threads = None
+      if FLAGS.use_dataset:
+        sess.run(initalizer)
+      else:
+        coord = tf.train.Coordinator()
+        threads = tf.train.start_queue_runners(sess=sess, coord=coord)
       real_batch_size = FLAGS.batch_size
       num_batches_per_epoch = int((EPOCH_SIZE + real_batch_size - 1)/ real_batch_size)
       iterations = FLAGS.epochs * num_batches_per_epoch 
@@ -319,8 +229,9 @@ def train():
           if step == iterations-1:
               checkpoint_path = os.path.join(FLAGS.train_dir, 'model.ckpt')
               saver.save(sess, checkpoint_path, global_step=step)
-      coord.request_stop()
-      coord.join(threads)
+      if not FLAGS.use_dataset:
+        coord.request_stop()
+        coord.join(threads)
       average_batch_time /= iterations
       print 'average_batch_time: ', average_batch_time
       print ('epoch_info: %s' % ','.join(epochs_info))

--- a/tools/tensorflow/cnn/alexnet/cifar10_input.py
+++ b/tools/tensorflow/cnn/alexnet/cifar10_input.py
@@ -91,7 +91,7 @@ def read_cifar10(filename_queue):
                            [result.depth, result.height, result.width])
   # Convert from [depth, height, width] to [height, width, depth].
   result.uint8image = tf.transpose(depth_major, [1, 2, 0])
-
+  #result.uint8image = depth_major
   return result
 
 
@@ -113,7 +113,7 @@ def _generate_image_and_label_batch(image, label, min_queue_examples,
   """
   # Create a queue that shuffles the examples, and then
   # read 'batch_size' images + labels from the example queue.
-  num_preprocess_threads = 4 
+  num_preprocess_threads = 8
   if shuffle:
     images, label_batch = tf.train.shuffle_batch(
         [image, label],
@@ -238,7 +238,7 @@ def inputs(eval_data, data_dir, batch_size):
   float_image = resized_image #tf.image.per_image_whitening(resized_image)
 
   # Ensure that the random shuffling has good mixing properties.
-  min_fraction_of_examples_in_queue = 0.4
+  min_fraction_of_examples_in_queue = .4
   min_queue_examples = int(num_examples_per_epoch *
                            min_fraction_of_examples_in_queue)
   print('min_queue_examples: ', min_queue_examples)

--- a/tools/tensorflow/cnn/alexnet/cifar10_input.py
+++ b/tools/tensorflow/cnn/alexnet/cifar10_input.py
@@ -23,6 +23,9 @@ import os
 
 #from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
+import cPickle
+import numpy as np
+
 
 # Process images of this size. Note that this differs from the original CIFAR
 # image size of 32 x 32. If one alters this number, then the entire model
@@ -33,6 +36,52 @@ IMAGE_SIZE = 32
 NUM_CLASSES = 10
 NUM_EXAMPLES_PER_EPOCH_FOR_TRAIN = 50000
 NUM_EXAMPLES_PER_EPOCH_FOR_EVAL = 10000
+
+class Dataset(object):
+  """Abstract class for cnn benchmarks dataset."""
+
+  def __init__(self, name, height=None, width=None, depth=None, data_dir=None):
+    self.name = name
+    self.height = height
+    self.width = width
+    self.depth = depth or 3
+    self.data_dir = data_dir
+
+  def __str__(self):
+    return self.name
+
+class Cifar10Data(Dataset):
+  """Configuration for cifar 10 dataset.
+
+  It will mount all the input images to memory.
+  """
+
+  def __init__(self, data_dir=None):
+    if data_dir is None:
+      raise ValueError('Data directory not specified')
+    super(Cifar10Data, self).__init__('cifar10', 32, 32, data_dir=data_dir)
+
+  def read_data_files(self, subset='train'):
+    """Reads from data file and return images and labels in a numpy array."""
+    if subset == 'train':
+      filenames = [os.path.join(self.data_dir, 'data_batch_%d' % i)
+                   for i in xrange(1, 6)]
+    elif subset == 'validation':
+      filenames = [os.path.join(self.data_dir, 'test_batch')]
+    else:
+      raise ValueError('Invalid data subset "%s"' % subset)
+
+    inputs = []
+    for filename in filenames:
+      with open(filename, 'r') as f:
+        inputs.append(cPickle.load(f))
+    # See http://www.cs.toronto.edu/~kriz/cifar.html for a description of the
+    # input format.
+    all_images = np.concatenate(
+        [each_input['data'] for each_input in inputs]).astype(np.float32)
+    all_labels = np.concatenate(
+        [each_input['labels'] for each_input in inputs]).astype(np.int32)
+    return all_images, all_labels
 
 
 def read_cifar10(filename_queue):
@@ -89,9 +138,11 @@ def read_cifar10(filename_queue):
   # from [depth * height * width] to [depth, height, width].
   depth_major = tf.reshape(tf.slice(record_bytes, [label_bytes], [image_bytes]),
                            [result.depth, result.height, result.width])
+  # Not needed when processing format is NCHW and not doing any
+  # distortions.
   # Convert from [depth, height, width] to [height, width, depth].
-  result.uint8image = tf.transpose(depth_major, [1, 2, 0])
-  #result.uint8image = depth_major
+  # result.uint8image = tf.transpose(depth_major, [1, 2, 0])
+  result.uint8image = depth_major
   return result
 
 
@@ -130,67 +181,36 @@ def _generate_image_and_label_batch(image, label, min_queue_examples,
 
   # Display the training images in the visualizer.
   #tf.image_summary('images', images)
-
   return images, tf.reshape(label_batch, [batch_size])
 
+# Exampe of how to pass to function dataset.map if doing
+# distortions or other work.
+#def _parse_function(image, label):
+  #image = tf.reshape(image,[3, 32, 32])
+  #image = tf.transpose(image, [1, 2, 0])
+#  return image, label
 
-def distorted_inputs(data_dir, batch_size):
-  """Construct distorted input for CIFAR training using the Reader ops.
 
-  Args:
-    data_dir: Path to the CIFAR-10 data directory.
-    batch_size: Number of images per batch.
-
-  Returns:
-    images: Images. 4D tensor of [batch_size, IMAGE_SIZE, IMAGE_SIZE, 3] size.
-    labels: Labels. 1D tensor of [batch_size] size.
-  """
-  filenames = [os.path.join(data_dir, 'data_batch_%d.bin' % i)
-               for i in xrange(1, 6)]
-  for f in filenames:
-    if not tf.gfile.Exists(f):
-      raise ValueError('Failed to find file: ' + f)
-
-  # Create a queue that produces the filenames to read.
-  filename_queue = tf.train.string_input_producer(filenames)
-
-  # Read examples from files in the filename queue.
-  read_input = read_cifar10(filename_queue)
-  reshaped_image = tf.cast(read_input.uint8image, tf.float32)
-
-  height = IMAGE_SIZE
-  width = IMAGE_SIZE
-
-  # Image processing for training the network. Note the many random
-  # distortions applied to the image.
-
-  # Randomly crop a [height, width] section of the image.
-  distorted_image = tf.random_crop(reshaped_image, [height, width, 3])
-
-  # Randomly flip the image horizontally.
-  distorted_image = tf.image.random_flip_left_right(distorted_image)
-
-  # Because these operations are not commutative, consider randomizing
-  # the order their operation.
-  distorted_image = tf.image.random_brightness(distorted_image,
-                                               max_delta=63)
-  distorted_image = tf.image.random_contrast(distorted_image,
-                                             lower=0.2, upper=1.8)
-
-  # Subtract off the mean and divide by the variance of the pixels.
-  float_image = tf.image.per_image_whitening(distorted_image)
-
-  # Ensure that the random shuffling has good mixing properties.
-  min_fraction_of_examples_in_queue = 0.4
-  min_queue_examples = int(NUM_EXAMPLES_PER_EPOCH_FOR_TRAIN *
-                           min_fraction_of_examples_in_queue)
-  print ('Filling queue with %d CIFAR images before starting to train. '
-         'This will take a few minutes.' % min_queue_examples)
-
-  # Generate a batch of images and labels by building up a queue of examples.
-  return _generate_image_and_label_batch(float_image, read_input.label,
-                                         min_queue_examples, batch_size,
-                                         shuffle=True)
+def dataSet(data_dir, batch_size):
+  data = Cifar10Data(data_dir=data_dir)
+  images, labels = data.read_data_files()
+  images = tf.cast(images, tf.float32)
+  labels = tf.cast(labels, tf.int32)
+  # Images do not need cropped the are all 32x32 they just need
+  # resized
+  images = tf.reshape(images,[50000,3,32,32])
+  
+  dataset = tf.contrib.data.Dataset.from_tensor_slices((images, labels))
+  dataset = dataset.map(lambda x,y:(x,y),num_threads=8,output_buffer_size=batch_size)
+  dataset = dataset.repeat()
+  dataset = dataset.shuffle(buffer_size=50000)
+  dataset = dataset.batch(batch_size)
+  
+  # Needed to let rest of the graph know the shape of the data
+  iterator = tf.contrib.data.Iterator.from_structure((tf.float32,tf.int32),
+                                                      ([batch_size,3,32,32],[batch_size,]))
+  initializer = iterator.make_initializer(dataset)
+  return iterator,initializer
 
 
 def inputs(eval_data, data_dir, batch_size):
@@ -224,19 +244,9 @@ def inputs(eval_data, data_dir, batch_size):
 
   # Read examples from files in the filename queue.
   read_input = read_cifar10(filename_queue)
+  # No need to crop and pad, the images all ready 32x32
   reshaped_image = tf.cast(read_input.uint8image, tf.float32)
-
-  height = IMAGE_SIZE
-  width = IMAGE_SIZE
-
-  # Image processing for evaluation.
-  # Crop the central [height, width] of the image.
-  resized_image = tf.image.resize_image_with_crop_or_pad(reshaped_image,
-                                                         width, height)
-
-  # Subtract off the mean and divide by the variance of the pixels.
-  float_image = resized_image #tf.image.per_image_whitening(resized_image)
-
+  
   # Ensure that the random shuffling has good mixing properties.
   min_fraction_of_examples_in_queue = .4
   min_queue_examples = int(num_examples_per_epoch *
@@ -244,6 +254,6 @@ def inputs(eval_data, data_dir, batch_size):
   print('min_queue_examples: ', min_queue_examples)
 
   # Generate a batch of images and labels by building up a queue of examples.
-  return _generate_image_and_label_batch(float_image, read_input.label,
+  return _generate_image_and_label_batch(reshaped_image, read_input.label,
                                          min_queue_examples, batch_size,
                                          shuffle=shuffle)


### PR DESCRIPTION
Changed Alexnet to use NCHW and also added dataset support.  The losses look similar to what they were before in the logs so I feel decent that everything is still copacetic.  

I did not test on TF 1.0 (release in Feb) but I did check that it works on TF 1.1.  I moved to tf.layers but that was part of the TF 1.0 API so I think it is fine.  

This should bring Alexnet down to single digits (6-7ms or so) for batch-size 128 on GTX 1080 even on TF 1.1 (so likely TF 1.0) but who knows still should be way better than 25ms (which is awful).  For Multi-GPU the results are also dramatic.  I do not recall the exact number on K80s without datasets because I am not very interested but I think it was in the 70ms range.  Again with my GPUs peered it is hard to know and your version of TF is a little older.  With TF 1.2 and DataSets it was ~36ms but the AWS instance is not exactly the same.  Either way it should be better.  FYI if you are still running this when TF 1.2+ is out and you use the data_sets=True flag you will need to download or point to the python version of CIFAR data set.  Again, I am not sure why my words were not understood.  I am not nor was I asking you to run TF 1.2 (it is not even released it is in RC).  I was sharing the numbers.  

I also deleted a bunch of dead code and commented out code.  It felt sloppy and made it hard to follow.  I am not very good at TensorFlow so let me know if I missed something.  I checked the losses and I do not think I changed anything that is unfair.  It looks like you had distortions turned off on the other platforms as well as TensorFlow.  I just made the path more direct to avoid any needless transforms.

No more changes on Alexnet from me.  This 100% matches the Performance Guide.  



